### PR TITLE
削除ボタンでエラーを修正

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
   before_action :set_item, except: [:index, :new, :create]
   before_action :contributor_confirmation, only: [:edit, :update, :destroy]
-  before_action :edit_item_redirect, only: [:edit]
+  before_action :edit_item_redirect, only: [:edit, :destroy]
   def index
     @items = Item.order(id: 'DESC')
   end


### PR DESCRIPTION
購入済みの商品を出品者が削除しようとしたらエラーが出る問題について、エラーを出さずにトップページにリダイレクトするようにしました。